### PR TITLE
Update decorators.py

### DIFF
--- a/volttron/client/vip/agent/decorators.py
+++ b/volttron/client/vip/agent/decorators.py
@@ -75,7 +75,7 @@ def annotations(obj, kind, name):
     # pylint: disable=protected-access
     try:
         annotations = obj._annotations
-    except AttributeError:
+    except (AttributeError, KeyError):
         annotations = {}
     try:
         items = annotations[name]


### PR DESCRIPTION
Handles keyerror when obj._annotations is not found within a set.